### PR TITLE
Fix to allow custom type conversion in parameter binding for trusted C# cmdlet

### DIFF
--- a/src/System.Management.Automation/engine/CmdletInfo.cs
+++ b/src/System.Management.Automation/engine/CmdletInfo.cs
@@ -69,7 +69,7 @@ namespace System.Management.Automation
             _PSSnapin = PSSnapin;
             _options = ScopedItemOptions.ReadOnly;
 
-            // CmdletInfo represents cmdlets exposed from assemblies, and on a DeviceGuard machine
+            // CmdletInfo represents cmdlets exposed from assemblies, and on a system locked down machine
             // only trusted assemblies can be loaded. Therefore, a CmdletInfo is always trusted.
             this.DefiningLanguageMode = PSLanguageMode.FullLanguage;
         }

--- a/src/System.Management.Automation/engine/CmdletInfo.cs
+++ b/src/System.Management.Automation/engine/CmdletInfo.cs
@@ -68,6 +68,9 @@ namespace System.Management.Automation
             _helpFilePath = helpFile;
             _PSSnapin = PSSnapin;
             _options = ScopedItemOptions.ReadOnly;
+
+            // CmdletInfo represents cmdlets exposed from assemblies, and on a DeviceGuard machine
+            // only trusted assemblies can be loaded. Therefore, a CmdletInfo is always trusted.
             this.DefiningLanguageMode = PSLanguageMode.FullLanguage;
         }
 

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -424,3 +424,331 @@
         }
     }
 }
+
+
+Describe "Custom type conversion in parameter binding" {
+    BeforeAll {
+        ## Prepare the script module
+        $content = @'
+    function Test-ScriptCmdlet {
+        [CmdletBinding(DefaultParameterSetName = "File")]
+        param(
+            [Parameter(Mandatory, ParameterSetName = "File")]
+            [System.IO.FileInfo] $File,
+
+            [Parameter(Mandatory, ParameterSetName = "StartInfo")]
+            [System.Diagnostics.ProcessStartInfo] $StartInfo
+        )
+
+        if ($PSCmdlet.ParameterSetName -eq "File") {
+            $File.Name
+        } else {
+            $StartInfo.FileName
+        }
+    }
+
+    function Test-ScriptFunction {
+        param(
+            [System.IO.FileInfo] $File,
+            [System.Diagnostics.ProcessStartInfo] $StartInfo
+        )
+
+        if ($null -ne $File) {
+            $File.Name
+        }
+        if ($null -ne $StartInfo) {
+            $StartInfo.FileName
+        }
+    }
+'@
+        Set-Content -Path $TestDrive\module.psm1 -Value $content -Force
+
+        ## Prepare the C# module
+        $code = @'
+    using System.IO;
+    using System.Diagnostics;
+    using System.Management.Automation;
+
+    namespace Test
+    {
+        [Cmdlet("Test", "BinaryCmdlet", DefaultParameterSetName = "File")]
+        public class TestCmdletCommand : PSCmdlet
+        {
+            [Parameter(Mandatory = true, ParameterSetName = "File")]
+            public FileInfo File { get; set; }
+
+            [Parameter(Mandatory = true, ParameterSetName = "StartInfo")]
+            public ProcessStartInfo StartInfo { get; set; }
+
+            protected override void ProcessRecord()
+            {
+                if (this.ParameterSetName == "File")
+                {
+                    WriteObject(File.Name);
+                }
+                else
+                {
+                    WriteObject(StartInfo.FileName);
+                }
+            }
+        }
+    }
+'@
+        $asmFile = [System.IO.Path]::GetTempFileName() + ".dll"
+        Add-Type -TypeDefinition $code -OutputAssembly $asmFile
+
+        ## Helper function to execute script
+        function Execute-Script {
+            [CmdletBinding(DefaultParameterSetName = "Script")]
+            param(
+                [Parameter(Mandatory)]
+                [powershell]$ps,
+
+                [Parameter(Mandatory, ParameterSetName = "Script")]
+                [string]$Script,
+
+                [Parameter(Mandatory, ParameterSetName = "Command")]
+                [string]$Command,
+
+                [Parameter(Mandatory, ParameterSetName = "Command")]
+                [string]$ParameterName,
+
+                [Parameter(Mandatory, ParameterSetName = "Command")]
+                [object]$Argument
+            )
+            $ps.Commands.Clear()
+            $ps.Streams.ClearStreams()
+
+            if ($PSCmdlet.ParameterSetName -eq "Script") {
+                $ps.AddScript($Script).Invoke()
+            } else {
+                $ps.AddCommand($Command).AddParameter($ParameterName, $Argument).Invoke()
+            }
+        }
+
+        ## Helper command strings
+        $changeToConstrainedLanguage = '$ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"'
+        $getLanguageMode = '$ExecutionContext.SessionState.LanguageMode'
+        $importScriptModule = "Import-Module $TestDrive\module.psm1"
+        $importCSharpModule = "Import-Module $asmFile"
+    }
+
+    AfterAll {
+        ## Set the LanguageMode to force rebuilding the type conversion cache.
+        ## This is needed because type conversions happen in the new powershell runspace with 'ConstrainedLanguage' mode
+        ## will be put in the type conversion cache, and that may affect the default session.
+        $ExecutionContext.SessionState.LanguageMode = "FullLanguage"
+    }
+
+    It "Custom type conversion in parameter binding is allowed in FullLanguage" {
+        ## Create a powershell instance for the test
+        $ps = [powershell]::Create()
+        try {
+            ## Import the modules in FullLanguage mode
+            Execute-Script -ps $ps -Script $importScriptModule
+            Execute-Script -ps $ps -Script $importCSharpModule
+
+            $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
+            $languageMode | Should Be 'FullLanguage'
+
+            $result1 = Execute-Script -ps $ps -Script "Test-ScriptCmdlet -File fileToUse"
+            $result1 | Should Be "fileToUse"
+
+            $result2 = Execute-Script -ps $ps -Script "Test-ScriptFunction -File fileToUse"
+            $result2 | Should Be "fileToUse"
+
+            $result3 = Execute-Script -ps $ps -Script "Test-BinaryCmdlet -File fileToUse"
+            $result3 | Should Be "fileToUse"
+
+            ## If the conversion involves setting properties of an instance of the target type,
+            ## then it's disallowed even for trusted cmdlets
+            $hashValue = @{ FileName = "filename"; Arguments = "args" }
+            $psobjValue = [PSCustomObject] $hashValue
+
+            ## Test 'Test-ScriptCmdlet -StartInfo' with IDictionary and PSObject with properties
+            $result4 = Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $hashValue
+            $result4 | Should Be "filename"
+            $result5 = Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
+            $result5 | Should Be "filename"
+
+            ## Test 'Test-ScriptFunction -StartInfo' with IDictionary and PSObject with properties
+            $result6 = Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $hashValue
+            $result6 | Should Be "filename"
+            $result7 = Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $psobjValue
+            $result7 | Should Be "filename"
+
+            ## Test 'Test-BinaryCmdlet -StartInfo' with IDictionary and PSObject with properties
+            $result8 = Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $hashValue
+            $result8 | Should Be "filename"
+            $result9 = Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
+            $result9 | Should Be "filename"
+        }
+        finally {
+            $ps.Dispose()
+        }
+    }
+
+    It "Some custom type conversion in parameter binding is allowed for trusted cmdlets in ConstrainedLanguage" {
+        ## Create a powershell instance for the test
+        $ps = [powershell]::Create()
+        try {
+            ## Import the modules in FullLanguage mode
+            Execute-Script -ps $ps -Script $importScriptModule
+            Execute-Script -ps $ps -Script $importCSharpModule
+
+            $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
+            $languageMode | Should Be 'FullLanguage'
+
+            ## Change to ConstrainedLanguage mode
+            Execute-Script -ps $ps -Script $changeToConstrainedLanguage
+            $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
+            $languageMode | Should Be 'ConstrainedLanguage'
+
+            $result1 = Execute-Script -ps $ps -Script "Test-ScriptCmdlet -File fileToUse"
+            $result1 | Should Be "fileToUse"
+
+            $result2 = Execute-Script -ps $ps -Script "Test-ScriptFunction -File fileToUse"
+            $result2 | Should Be "fileToUse"
+
+            $result3 = Execute-Script -ps $ps -Script "Test-BinaryCmdlet -File fileToUse"
+            $result3 | Should Be "fileToUse"
+
+            ## If the conversion involves setting properties of an instance of the target type,
+            ## then it's disallowed even for trusted cmdlets.
+            $hashValue = @{ FileName = "filename"; Arguments = "args" }
+            $psobjValue = [PSCustomObject] $hashValue
+
+            ## Test 'Test-ScriptCmdlet -StartInfo' with IDictionary and PSObject with properties
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $hashValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            ## Test 'Test-ScriptFunction -StartInfo' with IDictionary and PSObject with properties
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $hashValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $psobjValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            ## Test 'Test-BinaryCmdlet -StartInfo' with IDictionary and PSObject with properties
+            try {
+                Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $hashValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+            }
+
+            try {
+                Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+            }
+        }
+        finally {
+            $ps.Dispose()
+        }
+    }
+
+    It "Custom type conversion in parameter binding is NOT allowed for untrusted cmdlets in ConstrainedLanguage" {
+        ## Create a powershell instance for the test
+        $ps = [powershell]::Create()
+        try {
+            $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
+            $languageMode | Should Be 'FullLanguage'
+
+            ## Change to ConstrainedLanguage mode
+            Execute-Script -ps $ps -Script $changeToConstrainedLanguage
+            $languageMode = Execute-Script -ps $ps -Script $getLanguageMode
+            $languageMode | Should Be 'ConstrainedLanguage'
+
+            ## Import the modules in ConstrainedLanguage mode
+            Execute-Script -ps $ps -Script $importScriptModule
+            Execute-Script -ps $ps -Script $importCSharpModule
+
+            $result1 = Execute-Script -ps $ps -Script "Test-ScriptCmdlet -File fileToUse"
+            $result1 | Should Be $null
+            $ps.Streams.Error.Count | Should Be 1
+            $ps.Streams.Error[0].FullyQualifiedErrorId | Should Be "ParameterArgumentTransformationError,Test-ScriptCmdlet"
+
+            $result2 = Execute-Script -ps $ps -Script "Test-ScriptFunction -File fileToUse"
+            $result2 | Should Be $null
+            $ps.Streams.Error.Count | Should Be 1
+            $ps.Streams.Error[0].FullyQualifiedErrorId | Should Be "ParameterArgumentTransformationError,Test-ScriptFunction"
+
+            ## Binary cmdlets are always marked as trusted because only trusted assemblies can be loaded on DeviceGuard machine.
+            $result3 = Execute-Script -ps $ps -Script "Test-BinaryCmdlet -File fileToUse"
+            $result3 | Should Be "fileToUse"
+
+            ## Conversion that involves setting properties of an instance of the target type is disallowed.
+            $hashValue = @{ FileName = "filename"; Arguments = "args" }
+            $psobjValue = [PSCustomObject] $hashValue
+
+            ## Test 'Test-ScriptCmdlet -StartInfo' with IDictionary and PSObject with properties
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $hashValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            ## Test 'Test-ScriptFunction -StartInfo' with IDictionary and PSObject with properties
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $hashValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            try {
+                Execute-Script -ps $ps -Command "Test-ScriptFunction" -ParameterName "StartInfo" -Argument $psobjValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingArgumentTransformationException,Execute-Script"
+            }
+
+            ## Test 'Test-BinaryCmdlet -StartInfo' with IDictionary and PSObject with properties
+            try {
+                Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $hashValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+            }
+
+            try {
+                Execute-Script -ps $ps -Command "Test-BinaryCmdlet" -ParameterName "StartInfo" -Argument $psobjValue
+                throw "Expected exception was not thrown!"
+            } catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterBindingException,Execute-Script"
+            }
+        }
+        finally {
+            $ps.Dispose()
+        }
+    }
+}

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -560,8 +560,7 @@ Describe "Custom type conversion in parameter binding" {
             $result3 = Execute-Script -ps $ps -Script "Test-BinaryCmdlet -File fileToUse"
             $result3 | Should Be "fileToUse"
 
-            ## If the conversion involves setting properties of an instance of the target type,
-            ## then it's disallowed even for trusted cmdlets
+            ## Conversion involves setting properties of an instance of the target type is allowed in FullLanguage mode
             $hashValue = @{ FileName = "filename"; Arguments = "args" }
             $psobjValue = [PSCustomObject] $hashValue
 

--- a/test/powershell/engine/UntrustedDataMode.Tests.ps1
+++ b/test/powershell/engine/UntrustedDataMode.Tests.ps1
@@ -108,6 +108,11 @@ function Test-StartJob { Start-Job -ScriptBlock $args[0] }
     AfterAll {
         ## Clean up the powershell object
         $ps.Dispose()
+
+        ## Set the LanguageMode to force rebuilding the type conversion cache.
+        ## This is needed because type conversions happen in the new powershell runspace with 'ConstrainedLanguage' mode
+        ## will be put in the type conversion cache, and that may affect the default session.
+        $ExecutionContext.SessionState.LanguageMode = "FullLanguage"
     }
 
     It "verify the initial state of the test module 'UntrustedDataModeTest'" {


### PR DESCRIPTION
@PaulHigin @SteveL-MSFT can you please review this fix?